### PR TITLE
hostapp-update-hooks:999-resin-boot-cleaner: Clean-ups for EFI

### DIFF
--- a/layers/meta-resin-genericx86/recipes-core/images/resin-image-flasher.bbappend
+++ b/layers/meta-resin-genericx86/recipes-core/images/resin-image-flasher.bbappend
@@ -6,5 +6,3 @@ RESIN_BOOT_PARTITION_FILES_append = " \
     grub.cfg_internal: \
     "
 
-IMAGE_INSTALL_append = " efibootmgr"
-

--- a/layers/meta-resin-genericx86/recipes-core/images/resin-image.inc
+++ b/layers/meta-resin-genericx86/recipes-core/images/resin-image.inc
@@ -26,3 +26,5 @@ write_mbr() {
 }
 
 IMAGE_POSTPROCESS_COMMAND_append = " write_mbr; "
+
+IMAGE_INSTALL_append = " efibootmgr"

--- a/layers/meta-resin-genericx86/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
+++ b/layers/meta-resin-genericx86/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
@@ -25,4 +25,18 @@ if [ "$DURING_UPDATE" = "1" ]; then
 			fi
 		fi
 	fi
+
+	# make sure the bootstrap code (boot.img) is removed in case we are using EFI boot
+	if [ -d /sys/firmware/efi ] ; then
+		device="/dev/"$(findmnt --noheadings --canonicalize --output SOURCE "$RESIN_BOOT_MOUNTPOINT" | xargs lsblk -no pkname)
+		dd if=/dev/zero of=$device bs=446 count=1
+
+		# re-add the EFI entry for resinOS boot from internal media as some EFI firmwares are buggy and won't detect the old entry anymore
+		# first remove existing resinOS entries so we won't have duplicates
+		printf "[INFO] Re-add EFI boot entry for starting resinOS from internal media.\n"
+		mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+		duplicates=`efibootmgr | grep resinOS |sed 's/Boot*//g' | sed 's/* resinOS//g'`
+		for i in $duplicates; do efibootmgr -B -b $i; done
+		efibootmgr -c -d $device -p 1 -L "resinOS" -l "\EFI\BOOT\bootx64.efi"
+	fi
 fi


### PR DESCRIPTION
It's been observed on EFI machines that at the first boot after
provisioning there is some bootstrap code in the first sector of
the boot media (even though during provisioning we make sure we
remove this bootstrap code). In such a case (only on some machines),
the next time we reboot the machine, it will not recognize the media
as a valid EFI boot media and the boot will fail.

Changelog-entry: Make hostapp-update-hooks clean-up legacy grub to ensure correct future EFI boot
Signed-off-by: Florin Sarbu <florin@balena.io>

<img src="https://frontapp.com/assets/img/icons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_fvpf)