### PR TITLE
linux-yocto_%.bbappend: Enable ACPI_WMI

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -221,3 +221,9 @@ RESIN_CONFIGS[temp_sensors] = " \
     CONFIG_SENSORS_CORETEMP=m \
     CONFIG_SENSORS_NCT6775=m \
 "
+
+# requested by user
+RESIN_CONFIGS_append = " acpi_wmi"
+RESIN_CONFIGS[acpi_wmi] = " \
+    CONFIG_ACPI_WMI=m \
+"


### PR DESCRIPTION
As requested by customer

Changelog-entry: Build ACPI_WMI kernel module as requested by customer
Signed-off-by: Florin Sarbu <florin@balena.io>