### PR TITLE
linux-yocto_%.bbappend: Fix typo

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -251,7 +251,7 @@ RESIN_CONFIGS[ath10k_pci] = " \
 "
 
 RESIN_CONFIGS_append = " mmc_realtek_pci"
-RESIN_CONFIGS_DEPS[mmc_realtek__pci] = " \
+RESIN_CONFIGS_DEPS[mmc_realtek_pci] = " \
     CONFIG_MISC_RTSX_PCI=m \
 "
 RESIN_CONFIGS[mmc_realtek_pci] = " \


### PR DESCRIPTION
Changelog-entry: Fix typo that prevented microSD card support for Microsoft Surface Go
Signed-off-by: Florin Sarbu <florin@balena.io>