### PR TITLE
linux-yocto_%.bbappend: Add CONFIG options for TPM

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -272,3 +272,15 @@ RESIN_CONFIGS_DEPS[touchscreen_sp6] = " \
     CONFIG_INTEL_MEI_ME=m \
     CONFIG_HID_MULTITOUCH=m \
 "
+
+RESIN_CONFIGS_append = " tpm"
+RESIN_CONFIGS_DEPS[tpm] = " \
+    CONFIG_HW_RANDOM_TPM=y \
+    CONFIG_SECURITYFS=y \
+"
+RESIN_CONFIGS[tpm] = " \
+    CONFIG_TCG_TPM=m \
+    CONFIG_TCG_TIS_CORE=m \
+    CONFIG_TCG_TIS=m \
+    CONFIG_TCG_CRB=m \
+"


### PR DESCRIPTION
When TPM 2.0 support is present, the following devices
are available:
/dev/tpm0
/dev/tpmrm0

Changelog-entry: Added TPM kernel module support
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>