### PR TITLE
linux-yocto: Set ATA_PIIX as built-in

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -303,3 +303,10 @@ RESIN_CONFIGS[ad5593r] = " \
 RESIN_CONFIGS_DEPS[ad5593r] = " \
     CONFIG_IIO=m \
 "
+
+# set ATA_PIIX as built-in so we can boot legacy IDE mode without adding the ata_piix driver in the initramfs
+# (some boards do not support AHCI mode)
+RESIN_CONFIGS_append_genericx86-64 = " ata_piix"
+RESIN_CONFIGS[ata_piix] = " \
+    CONFIG_ATA_PIIX=y \
+"


### PR DESCRIPTION
Some boards only support SATA IDE mode (no AHCI) so in order to boot
correctly without adding the ata_piix kernel module in the rootfs we
make the driver as built-in.

Changelog-entry: Set ATA_PIIX as built-in so we can boot legacy IDE mode without adding the ata_piix driver in the initramfs
Signed-off-by: Florin Sarbu <florin@balena.io>