### PR TITLE
linux-yocto_%.bbappend: Enable PINCTRL_BAYTRAIL

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -310,3 +310,9 @@ RESIN_CONFIGS_append_genericx86-64 = " ata_piix"
 RESIN_CONFIGS[ata_piix] = " \
     CONFIG_ATA_PIIX=y \
 "
+
+# requested by customer
+RESIN_CONFIGS_append_genericx86-64 = " pinctrl_baytrail"
+RESIN_CONFIGS[pinctrl_baytrail] = " \
+    CONFIG_PINCTRL_BAYTRAIL=y \
+"


### PR DESCRIPTION
Requested by customer

Changelog-entry: Enable PINCTRL_BAYTRAIL support in the kernel
Signed-off-by: Florin Sarbu <florin@balena.io>