### PR TITLE
linux-yocto: Enable USB Winchiphead CH341 Single Port Serial Driver

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -316,3 +316,9 @@ RESIN_CONFIGS_append_genericx86-64 = " pinctrl_baytrail"
 RESIN_CONFIGS[pinctrl_baytrail] = " \
     CONFIG_PINCTRL_BAYTRAIL=y \
 "
+
+# requested by user (this module was previously available but apparently got removed when we updated to warrior and a new kernel)
+RESIN_CONFIGS_append_genericx86-64 = " ch341"
+RESIN_CONFIGS[ch341] = " \
+    CONFIG_USB_SERIAL_CH341=m \
+"


### PR DESCRIPTION
Changelog-entry: Enable USB Winchiphead CH341 Single Port Serial Driver
Signed-off-by: Florin Sarbu <florin@balena.io>