### PR TITLE
linux-yocto: Backport iwlwifi patches for multicast frames

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/files/0007-BUGFIX-iwlwifi-mvm-Allow-multicast-~ta-frames-only-when-associated.patch
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/files/0007-BUGFIX-iwlwifi-mvm-Allow-multicast-~ta-frames-only-when-associated.patch
@@ -1,0 +1,82 @@
+From 00925d1ae225cdd547e9d96ecb0abf609c593cff Mon Sep 17 00:00:00 2001
+From: Ilan Peer <ilan.peer@intel.com>
+Date: Tue, 11 Jun 2019 11:45:55 +0300
+Subject: [PATCH] [BUGFIX] iwlwifi: mvm: Allow multicast data frames only when
+ associated
+
+The MAC context configuration always allowed multicast data frames
+to pass to the driver for all MAC context types, and in the
+case of station MAC context both when associated and when not
+associated.
+
+One of the outcomes of this configuration is having the FW forward
+encrypted multicast frames to the driver with Rx status indicating
+that the frame was not decrypted (as expected, since no keys were
+configured yet) which in turn results with unnecessary error
+messages.
+
+Change this behavior to allow multicast data frames only when they
+are actually expected, e.g., station MAC context is associated etc.
+
+type=bugfix
+ticket=jira:WIFI-24625
+fixes=unknown
+
+Change-Id: I8e7a197d413b804815758102bacde1051a0f20e0
+Signed-off-by: Ilan Peer <ilan.peer@intel.com>
+Reviewed-on: https://git-amr-3.devtools.intel.com/gerrit/225375
+automatic-review: ec ger unix iil jenkins <EC.GER.UNIX.IIL.JENKINS@INTEL.COM>
+Tested-by: ec ger unix iil jenkins <EC.GER.UNIX.IIL.JENKINS@INTEL.COM>
+Reviewed-by: Luciano Coelho <luciano.coelho@intel.com>
+x-iwlwifi-stack-dev: 7413061ff579dce6c16b27721e847f822b3b8485
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c | 9 ++++++---
+ 1 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c b/drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c
+index 50b563b..9c26dd4 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c
+@@ -555,7 +555,7 @@ static void iwl_mvm_mac_ctxt_cmd_common(struct iwl_mvm *mvm,
+ 		cpu_to_le32(vif->bss_conf.use_short_slot ?
+ 			    MAC_FLG_SHORT_SLOT : 0);
+ 
+-	cmd->filter_flags = cpu_to_le32(MAC_FILTER_ACCEPT_GRP);
++	cmd->filter_flags = 0;
+ 
+ 	for (i = 0; i < IEEE80211_NUM_ACS; i++) {
+ 		u8 txf = iwl_mvm_mac_ac_to_tx_fifo(mvm, i);
+@@ -668,6 +668,7 @@ static int iwl_mvm_mac_ctxt_cmd_sta(struct iwl_mvm *mvm,
+ 			       dtim_offs);
+ 
+ 		ctxt_sta->is_assoc = cpu_to_le32(1);
++		cmd.filter_flags |= cpu_to_le32(MAC_FILTER_ACCEPT_GRP);
+ 	} else {
+ 		ctxt_sta->is_assoc = cpu_to_le32(0);
+ 
+@@ -713,7 +714,8 @@ static int iwl_mvm_mac_ctxt_cmd_listener(struct iwl_mvm *mvm,
+ 				       MAC_FILTER_IN_CONTROL_AND_MGMT |
+ 				       MAC_FILTER_IN_BEACON |
+ 				       MAC_FILTER_IN_PROBE_REQUEST |
+-				       MAC_FILTER_IN_CRC32);
++				       MAC_FILTER_IN_CRC32 |
++				       MAC_FILTER_ACCEPT_GRP);
+ 	ieee80211_hw_set(mvm->hw, RX_INCLUDES_FCS);
+ 
+ 	/* Allocate sniffer station */
+@@ -737,7 +739,8 @@ static int iwl_mvm_mac_ctxt_cmd_ibss(struct iwl_mvm *mvm,
+ 	iwl_mvm_mac_ctxt_cmd_common(mvm, vif, &cmd, NULL, action);
+ 
+ 	cmd.filter_flags = cpu_to_le32(MAC_FILTER_IN_BEACON |
+-				       MAC_FILTER_IN_PROBE_REQUEST);
++				       MAC_FILTER_IN_PROBE_REQUEST |
++				       MAC_FILTER_ACCEPT_GRP);
+ 
+ 	/* cmd.ibss.beacon_time/cmd.ibss.beacon_tsf are curently ignored */
+ 	cmd.ibss.bi = cpu_to_le32(vif->bss_conf.beacon_int);
+-- 
+2.7.4
+

--- a/layers/meta-balena-genericx86/recipes-kernel/linux/files/0008-BUGFIX-iwlwifi-mvm-Allow-multicast-~ta-frames-only-when-authorized.patch
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/files/0008-BUGFIX-iwlwifi-mvm-Allow-multicast-~ta-frames-only-when-authorized.patch
@@ -1,0 +1,110 @@
+From 2fc5847ec08431b1b6e04aa799db686f53eeb31c Mon Sep 17 00:00:00 2001
+From: Ilan Peer <ilan.peer@intel.com>
+Date: Tue, 18 Jun 2019 08:55:50 +0300
+Subject: [PATCH] [BUGFIX] iwlwifi: mvm: Allow multicast data frames only when
+ authorized
+
+The fix introduced in commit 7413061ff579 ("[BUGFIX] iwlwifi: mvm: Allow
+multicast data frames only when associated") was not complete as it
+still allowed multicast data frames to be forwarded to the host
+while GTK was not installed yet.
+
+To fix this, indicate the FW that multicast data frames should be
+forwarded to the host only after the AP station is authorized.
+
+type=bugfix
+ticket=jira:WIFI-24625
+fixes=I8e7a197d413b804815758102bacde1051a0f20e0
+
+Change-Id: I7d967e372eed42b182ff55de1f68fc2573233fc6
+Signed-off-by: Ilan Peer <ilan.peer@intel.com>
+Reviewed-on: https://git-amr-3.devtools.intel.com/gerrit/226274
+Tested-by: ec ger unix iil jenkins <EC.GER.UNIX.IIL.JENKINS@INTEL.COM>
+Reviewed-by: Grumbach, Emmanuel <emmanuel.grumbach@intel.com>
+Reviewed-by: Luciano Coelho <luciano.coelho@intel.com>
+x-iwlwifi-stack-dev: 694d4c4b5529a34e4b11d4020424772f9f494eb7
+
+Patch adapted for kernel 5.0.3 from the one at https://kernel.googlesource.com/pub/scm/linux/kernel/git/iwlwifi/backport-iwlwifi/+/2fc5847ec08431b1b6e04aa799db686f53eeb31c
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c | 26 ++++++++++++++++++++++-
+ drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c | 10 +++++++++
+ 2 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c b/drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c
+index f2792f3..0d075a3 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.c
+@@ -722,6 +722,8 @@ static int iwl_mvm_mac_ctxt_cmd_sta(struct iwl_mvm *mvm,
+ 	/* We need the dtim_period to set the MAC as associated */
+ 	if (vif->bss_conf.assoc && vif->bss_conf.dtim_period &&
+ 	    !force_assoc_off) {
++		struct iwl_mvm_vif *mvmvif = iwl_mvm_vif_from_mac80211(vif);
++		u8 ap_sta_id = mvmvif->ap_sta_id;
+ 		u32 dtim_offs;
+ 
+ 		/*
+@@ -757,7 +759,29 @@ static int iwl_mvm_mac_ctxt_cmd_sta(struct iwl_mvm *mvm,
+ 			       dtim_offs);
+ 
+ 		ctxt_sta->is_assoc = cpu_to_le32(1);
+-		cmd.filter_flags |= cpu_to_le32(MAC_FILTER_ACCEPT_GRP);
++
++               /*
++                * allow multicast data frames only as long as the station is
++                * authorized, i.e., GTK keys are already installed (if needed)
++                */
++               if (ap_sta_id < IWL_MVM_STATION_COUNT) {
++			struct ieee80211_sta *sta;
++
++			rcu_read_lock();
++
++			sta = rcu_dereference(mvm->fw_id_to_mac_id[ap_sta_id]);
++			if (!IS_ERR_OR_NULL(sta)) {
++				struct iwl_mvm_sta *mvmsta =
++					iwl_mvm_sta_from_mac80211(sta);
++
++				if (mvmsta->sta_state ==
++				    IEEE80211_STA_AUTHORIZED)
++					cmd.filter_flags |=
++						cpu_to_le32(MAC_FILTER_ACCEPT_GRP);
++			}
++
++			rcu_read_unlock();
++		}
+ 	} else {
+ 		ctxt_sta->is_assoc = cpu_to_le32(0);
+ 
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c b/drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c
+index 97dc464..b6d5ef9 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c
+@@ -3003,6 +3003,13 @@ static int iwl_mvm_mac_sta_state(struct ieee80211_hw *hw,
+ 		/* enable beacon filtering */
+ 		WARN_ON(iwl_mvm_enable_beacon_filter(mvm, vif, 0));
+ 
++		/*
++		 * Now that the station is authorized, i.e., keys were already
++		 * installed, need to indicate to the FW that
++		 * multicast data frames can be forwarded to the driver
++		 */
++		iwl_mvm_mac_ctxt_changed(mvm, vif, false, NULL);
++
+ 		iwl_mvm_rs_rate_init(mvm, sta, mvmvif->phy_ctxt->channel->band,
+ 				     true);
+ 
+@@ -3015,6 +3022,9 @@ static int iwl_mvm_mac_sta_state(struct ieee80211_hw *hw,
+ 			ret = 0;
+ 	} else if (old_state == IEEE80211_STA_AUTHORIZED &&
+ 		   new_state == IEEE80211_STA_ASSOC) {
++		/* Multicast data frames are no longer allowed */
++		iwl_mvm_mac_ctxt_changed(mvm, vif, false, NULL);
++
+ 		/* disable beacon filtering */
+ 		WARN_ON(iwl_mvm_disable_beacon_filter(mvm, vif, 0));
+ 		ret = 0;
+-- 
+2.7.4
+

--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -9,6 +9,8 @@ SRC_URI += " \
     file://0004-NFLX-2019-001-SACK-Slowness.patch \
     file://0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
     file://0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
+    file://0007-BUGFIX-iwlwifi-mvm-Allow-multicast-~ta-frames-only-when-associated.patch \
+    file://0008-BUGFIX-iwlwifi-mvm-Allow-multicast-~ta-frames-only-when-authorized.patch \
 "
 SRC_URI_append_surface-pro-6 = " \
     file://0003-ipts.patch \


### PR DESCRIPTION
These patches fix the following issue related to multicast frames:
Unhandled alg: 0x707

Changelog-entry: Backport iwlwifi patches for multicast frames handling
Signed-off-by: Florin Sarbu <florin@balena.io>