### PR TITLE
resin-init-flasher-board: Conditionally mount efivarfs

### DIFF
--- a/layers/meta-balena-genericx86/recipes-support/resin-init/resin-init-flasher-board/resin-init-flasher-board
+++ b/layers/meta-balena-genericx86/recipes-support/resin-init/resin-init-flasher-board/resin-init-flasher-board
@@ -58,7 +58,7 @@ sync
 [ -z $INSTALL_UEFI ] && exit 0
 
 # remove existing resinOS entries so we won't have duplicates
-mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+if ! mount | grep efivarfs > /dev/null; then mount -t efivarfs efivarfs /sys/firmware/efi/efivars; fi
 duplicates=`efibootmgr | grep resinOS |sed 's/Boot*//g' | sed 's/* resinOS//g'`
 for i in $duplicates; do efibootmgr -B -b $i; done
 


### PR DESCRIPTION
In newer OS images, when the flasher runs, the efivarfs
is already mounted and this makes the flasher script error out.
Let's make sure we run the mount command only if efivarfs is not
already mounted.

Changelog-entry: Only mount efivarfs in flasher if it's not already mounted
Signed-off-by: Florin Sarbu <florin@balena.io>