### PR TITLE
linux-yocto: Enable I2C on Intel Atom Cherry Trail based SoCs

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -325,3 +325,9 @@ RESIN_CONFIGS_append_genericx86-64 = " ch341"
 RESIN_CONFIGS[ch341] = " \
     CONFIG_USB_SERIAL_CH341=m \
 "
+
+RESIN_CONFIGS_append_genericx86-64 = " i2c_designware"
+RESIN_CONFIGS[i2c_designware] = " \
+    CONFIG_I2C_DESIGNWARE_PLATFORM=m \
+    CONFIG_I2C_DESIGNWARE_PCI=m \
+"


### PR DESCRIPTION
We switched to kernel 5.0.3 and by default this kernel lacks
DESIGNWARE I2C support.
This is needed to fix missing /dev/sri/card0 on Intel Atom
Cherry Trail based boards.

Changelog-entry: Enable I2C support on kernel 5.x for Intel Atom Cherry Trail based SoCs
Signed-off-by: Florin Sarbu <florin@balena.io>