### PR TITLE
grub-conf: Include in cmdline partitions UUID when available

### DIFF
--- a/layers/meta-balena-genericx86/recipes-bsp/grub/grub-conf/grub.cfg_internal_template
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/grub-conf/grub.cfg_internal_template
@@ -7,6 +7,7 @@ insmod loadenv
 timeout=@@TIMEOUT@@
 resin_root_part=2
 upgrade_available=0
+grub_cmdline=""
 
 load_env
 
@@ -21,32 +22,52 @@ if [ ${upgrade_available} = 1 ] ; then
  fi
 fi
 
+# Append to grub_cmdline the UUID value for all the OS partitions. These UUIDs
+# are stored on the boot partition (/os_fs_uuids.txt). This file contains a
+# line for each partition UUID. For example: "uuid_boot=FFFF-FFFF".
+# Also, the assumed label to kernel parameter mapping is:
+#   resin-boot -> uuid_boot
+#   resin_rootA -> uuid_roota
+#   resin_rootB -> uuid_rootb
+#   resin_state -> uuid_state
+#   resin_data -> uuid_data
+search --set=boot --label resin-boot
+source (${boot})/os_fs_uuids.txt
+if [ x${uuid_boot} != x ]; then
+ # If one is available we assume all the rest are as well.
+ grub_cmdline="${grub_cmdline} uuid_boot=${uuid_boot}"
+ grub_cmdline="${grub_cmdline} uuid_roota=${uuid_roota}"
+ grub_cmdline="${grub_cmdline} uuid_rootb=${uuid_rootb}"
+ grub_cmdline="${grub_cmdline} uuid_state=${uuid_state}"
+ grub_cmdline="${grub_cmdline} uuid_data=${uuid_data}"
+fi
+
 menuentry 'boot'{
 if [ ${bootcount} = 2 ] ; then
  if [ ${resin_root_part} = 2 ] ; then
   search --set=root --label resin-rootB
-  linux /boot/bzImage root=LABEL=resin-rootB @@KERNEL_CMDLINE@@
+  linux /boot/bzImage root=LABEL=resin-rootB @@KERNEL_CMDLINE@@ ${grub_cmdline}
  else
   search --set=root --label resin-rootA
-  linux /boot/bzImage root=LABEL=resin-rootA @@KERNEL_CMDLINE@@
+  linux /boot/bzImage root=LABEL=resin-rootA @@KERNEL_CMDLINE@@ ${grub_cmdline}
  fi
 else
  if [ ${resin_root_part} = 2 ] ; then
   search --set=root --label resin-rootA
-  linux /boot/bzImage root=LABEL=resin-rootA @@KERNEL_CMDLINE@@
+  linux /boot/bzImage root=LABEL=resin-rootA @@KERNEL_CMDLINE@@ ${grub_cmdline}
  else
   search --set=root --label resin-rootB
-  linux /boot/bzImage root=LABEL=resin-rootB @@KERNEL_CMDLINE@@
+  linux /boot/bzImage root=LABEL=resin-rootB @@KERNEL_CMDLINE@@ ${grub_cmdline}
  fi
 fi
 }
 
 menuentry 'manualfallbackA' {
 search --set=root --label resin-rootA
-linux /boot/bzImage root=LABEL=resin-rootA @@KERNEL_CMDLINE@@
+linux /boot/bzImage root=LABEL=resin-rootA @@KERNEL_CMDLINE@@ ${grub_cmdline}
 }
 
 menuentry 'manualfallbackB' {
 search --set=root --label resin-rootB
-linux /boot/bzImage root=LABEL=resin-rootB @@KERNEL_CMDLINE@@
+linux /boot/bzImage root=LABEL=resin-rootB @@KERNEL_CMDLINE@@ ${grub_cmdline}
 }


### PR DESCRIPTION
This PR assumes support in `meta-balena`: https://github.com/balena-os/meta-balena/pull/1677

After first boot, the OS will generate the UUID of every partition and
store their values in a boot partition file. Source this file and pass
these UUIDs, when available, as part of cmdline so that the OS can use
them for partition mounts.

Changelog-entry: Pass partitions UUID in cmdline when available
Signed-off-by: Andrei Gherzan <andrei@balena.io>