### PR TITLE
linux: enable Broadcom 43xx wifi drivers

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -59,6 +59,11 @@ FILES_${PN}-ath10k-qca6174= " \
     ${nonarch_base_libdir}/firmware/ath10k/QCA6174/hw3.0/firmware-6.bin \
 "
 
+PACKAGES =+ "${PN}-broadcom_43xx"
+FILES_${PN}-broadcom_43xx= " \
+    ${nonarch_base_libdir}/firmware/b43/ucode15.fw \
+"
+
 PACKAGES =+ "${PN}-i915-kbl"
 FILES_${PN}-i915-kbl = " \
     ${nonarch_base_libdir}/firmware/i915/kbl_dmc_ver1_01.bin \

--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -145,6 +145,16 @@ RESIN_CONFIGS[rtl_wifi]=" \
     CONFIG_RTL8192CU=m \
 "
 
+# Enable WiFi adapters that use Broadcom 43xx chipset
+RESIN_CONFIGS_append = " broadcom_wifi"
+RESIN_CONFIGS[broadcom_wifi]=" \
+    CONFIG_B43=m \
+    CONFIG_B43_PHY_G=y \
+    CONFIG_B43_PHY_N=y \
+    CONFIG_B43_PHY_LP=y \
+    CONFIG_B43_PHY_HT=y \
+"
+
 # Add overlayfs module in the rootfs (some user containers need this even though we do not yet switch from aufs to overlay2 as balena storage driver)
 RESIN_CONFIGS_append = " overlayfs"
 RESIN_CONFIGS[overlayfs] = " \


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>