### PR TITLE
linux-yocto: Enable ixgbe driver for genericx86-64

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -352,3 +352,9 @@ RESIN_CONFIGS_append_surface-go = " i2c_hid"
 RESIN_CONFIGS[i2c_hid] = " \
     CONFIG_I2C_HID=m \
 "
+
+# requested by customer
+RESIN_CONFIGS_append_genericx86-64 = " ixgbe"
+RESIN_CONFIGS[ixgbe] = " \
+    CONFIG_IXGBE=m \
+"


### PR DESCRIPTION
Changelog-entry: Enable the ixgbe driver for the genericx86-64 machine
Signed-off-by: Florin Sarbu <florin@balena.io>