### PR TITLE
linux-yocto: Enable xillybus pcie driver for genericx86-64

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -358,3 +358,10 @@ RESIN_CONFIGS_append_genericx86-64 = " ixgbe"
 RESIN_CONFIGS[ixgbe] = " \
     CONFIG_IXGBE=m \
 "
+
+# requested by customer
+RESIN_CONFIGS_append_genericx86-64 = " xillybus"
+RESIN_CONFIGS[xillybus] = " \
+    CONFIG_XILLYBUS=m \
+    CONFIG_XILLYBUS_PCIE=m \
+"


### PR DESCRIPTION
Changelog-entry: Enable the xillybus pcie driver for the genericx86-64 machine
Signed-off-by: Florin Sarbu <florin@balena.io>