### PR TITLE
docs: Updating getting started links

### DIFF
--- a/genericx86-64.coffee
+++ b/genericx86-64.coffee
@@ -35,9 +35,9 @@ module.exports =
 	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:
-		windows: 'http://docs.resin.io/nuc/nodejs/getting-started/#adding-your-first-device'
-		osx: 'http://docs.resin.io/nuc/nodejs/getting-started/#adding-your-first-device'
-		linux: 'http://docs.resin.io/nuc/nodejs/getting-started/#adding-your-first-device'
+		windows: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		osx: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		linux: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
 
 	yocto:
 		machine: 'genericx86-64'

--- a/surface-go.coffee
+++ b/surface-go.coffee
@@ -31,9 +31,9 @@ module.exports =
 	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:
-		windows: 'http://docs.resin.io/surface-go/nodejs/getting-started/#adding-your-first-device'
-		osx: 'http://docs.resin.io/surface-go/nodejs/getting-started/#adding-your-first-device'
-		linux: 'http://docs.resin.io/surface-go/nodejs/getting-started/#adding-your-first-device'
+		windows: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		osx: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		linux: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
 
 	yocto:
 		machine: 'surface-go'

--- a/surface-pro-6.coffee
+++ b/surface-pro-6.coffee
@@ -31,9 +31,9 @@ module.exports =
 	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:
-		windows: 'http://docs.resin.io/surface-pro-6/nodejs/getting-started/#adding-your-first-device'
-		osx: 'http://docs.resin.io/surface-pro-6/nodejs/getting-started/#adding-your-first-device'
-		linux: 'http://docs.resin.io/surface-pro-6/nodejs/getting-started/#adding-your-first-device'
+		windows: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		osx: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		linux: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
 
 	yocto:
 		machine: 'surface-pro-6'


### PR DESCRIPTION
There are no Surface getting started docs. Are the NUC instructions currently the best place to point?

Change-type: patch
Signed-off-by: Gareth Davies <gareth@balena.io>