### PR TITLE
resin-init-flasher-board: Tweak detection of internal media

### DIFF
--- a/layers/meta-balena-genericx86/recipes-support/resin-init/resin-init-flasher-board/resin-init-flasher-board
+++ b/layers/meta-balena-genericx86/recipes-support/resin-init/resin-init-flasher-board/resin-init-flasher-board
@@ -32,7 +32,7 @@ for d in $INTERNAL_DEVICE_KERNEL; do
         echo "[resin-init-flasher-board] $d is our install media, skip it..."
         continue
     fi
-    if [ -b "/dev/$d" ]; then
+    if fdisk -l | grep -q "$d"; then
         internal_dev=$d
         break
     fi


### PR DESCRIPTION
When installing UEFI grub, it is better to use fdisk to check that
an internal media is a suitable block device rather than using
the shell internal block testing feature. This is because there
is at least a case when the kernel lists an ASMT 2115 controller
as /dev/sda but that is not an actual drive so it cannot be
written to and the flashing procedure will error out.

Changelog-entry: Tweak how the flasher asserts that internal media is valid for being installed UEFI grub on
Signed-off-by: Florin Sarbu <florin@balena.io>