### PR TITLE
Add linux-firmware-iwlwifi-3168 to support wifi adapters for older NUCs

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -6,6 +6,7 @@ CONNECTIVITY_FIRMWARES =+ " \
 	linux-firmware-ibt-18-16-1 \
 	linux-firmware-ibt-hw-37-7 \
 	linux-firmware-ibt-hw-37-8 \
+	linux-firmware-iwlwifi-3168 \
 	linux-firmware-iwlwifi-9000 \
 	linux-firmware-pcie8897 \
 	linux-firmware-rtl8723 \

--- a/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -73,6 +73,11 @@ FILES_${PN}-ipts-v102 = " \
     ${nonarch_base_libdir}/firmware/intel/ipts/* \
 "
 
+PACKAGES =+ "${PN}-iwlwifi-3168"
+FILES_${PN}-iwlwifi-3168 = " \
+    ${nonarch_base_libdir}/firmware/iwlwifi-3168-* \
+"
+
 do_install_append() {
     install -d ${D}${nonarch_base_libdir}/firmware/brcm/
     install -m 0644 ${WORKDIR}/raspbian-nf/brcm/brcmfmac43455-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/


### PR DESCRIPTION
Fixes #277 

Change-type: patch