### PR TITLE
linux-yocto_%.bbappend: Enable the i40e kernel driver

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -365,3 +365,9 @@ RESIN_CONFIGS[xillybus] = " \
     CONFIG_XILLYBUS=m \
     CONFIG_XILLYBUS_PCIE=m \
 "
+
+# requested by customer
+RESIN_CONFIGS_append_genericx86-64 = " i40e"
+RESIN_CONFIGS[i40e] = " \
+    CONFIG_I40E=m \
+"


### PR DESCRIPTION
Requested by customer for the genericx86-64 machine

Changelog-entry: Enable the i40e kernel driver for the genericx86-64 machine
Signed-off-by: Florin Sarbu <florin@balena.io>