### PR TITLE
linux-yocto: Enable KVM support for genericx86-64 

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -139,6 +139,14 @@ RESIN_CONFIGS[usb_audio]=" \
     CONFIG_SND_USB_AUDIO=m \
 "
 
+# Enable KVM virtualization support
+RESIN_CONFIGS_append = " kvm"
+RESIN_CONFIGS[kvm] = " \
+    CONFIG_KVM=m \
+    CONFIG_KVM_INTEL=m \
+    CONFIG_KVM_AMD=m \
+"
+
 # Enable WiFi adapters that use Realtek chipset (like Edimax EW-7811Un)
 RESIN_CONFIGS_append = " rtl_wifi"
 RESIN_CONFIGS[rtl_wifi]=" \


### PR DESCRIPTION
Following discussion in [this forum thread](https://forums.balena.io/t/passing-kvm-virtualization-in-balena-container/7780), this PR enables KVM support for intel boards.

We're using it to run a legacy windows app, I know some other customers are doing the same, so certainly a useful one to have.