### PR TITLE
linux-firmware: Add firmware for Intel wifi chipset on NUC 10th gen

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -9,6 +9,7 @@ CONNECTIVITY_FIRMWARES =+ " \
 	linux-firmware-iwlwifi-3168 \
 	linux-firmware-iwlwifi-9000 \
 	linux-firmware-iwlwifi-9260 \
+	linux-firmware-iwlwifi-qu-b0-hr-b0 \
 	linux-firmware-pcie8897 \
 	linux-firmware-rtl8723 \
 	linux-firmware-rtl8821 \


### PR DESCRIPTION
Changelog-entry: Add firmware for Intel wifi chipset on NUC 10th gen
Signed-off-by: Florin Sarbu <florin@balena.io>