### PR TITLE
Add grub extra_os_cmdline support

### DIFF
--- a/layers/meta-balena-genericx86/recipes-bsp/grub/grub-conf.bb
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/grub-conf.bb
@@ -32,6 +32,7 @@ do_deploy() {
     fi
 
     install -m 644 ${WORKDIR}/grubenv ${DEPLOYDIR}/grubenv
+    touch ${DEPLOYDIR}/grub_extraenv
 
 }
 

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/grub-conf/grub.cfg_external
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/grub-conf/grub.cfg_external
@@ -1,10 +1,12 @@
 # Automatically created by OE
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 insmod ext2
+insmod configfile
+source /grub/grub_extraenv
 default=boot
 timeout=3
 
 menuentry 'flash'{
 search --set=root --label flash-rootA
-linux /boot/bzImage root=LABEL=flash-rootA flasher rootwait
+linux /boot/bzImage root=LABEL=flash-rootA flasher rootwait ${extra_os_cmdline}
 }

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/grub-conf/grub.cfg_internal_template
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/grub-conf/grub.cfg_internal_template
@@ -6,11 +6,13 @@ insmod test
 insmod loadenv
 insmod regexp
 insmod probe
+insmod configfile
 timeout=@@TIMEOUT@@
 resin_root_part=2
 upgrade_available=0
 
 load_env
+source /grub/grub_extraenv
 
 if [ ${upgrade_available} = 1 ] ; then
  if [ ${bootcount} = 1 ] ; then
@@ -52,15 +54,15 @@ else
   get_root_uuid "resin-rootB"
  fi
 fi
-linux /boot/bzImage root=UUID=${root_uuid} @@KERNEL_CMDLINE@@
+linux /boot/bzImage root=UUID=${root_uuid} @@KERNEL_CMDLINE@@ ${extra_os_cmdline}
 }
 
 menuentry 'manualfallbackA' {
   get_root_uuid "resin-rootA"
-  linux /boot/bzImage root=UUID=${root_uuid} @@KERNEL_CMDLINE@@
+  linux /boot/bzImage root=UUID=${root_uuid} @@KERNEL_CMDLINE@@ ${extra_os_cmdline}
 }
 
 menuentry 'manualfallbackB' {
   get_root_uuid "resin-rootB"
-  linux /boot/bzImage root=UUID=${root_uuid} @@KERNEL_CMDLINE@@
+  linux /boot/bzImage root=UUID=${root_uuid} @@KERNEL_CMDLINE@@ ${extra_os_cmdline}
 }

--- a/layers/meta-balena-genericx86/recipes-core/images/resin-image.inc
+++ b/layers/meta-balena-genericx86/recipes-core/images/resin-image.inc
@@ -17,6 +17,8 @@ RESIN_BOOT_PARTITION_FILES = " \
     grub/x86_64-efi:/EFI/BOOT/x86_64-efi/ \
     grubenv:/grub/grubenv \
     grubenv:/EFI/BOOT/grubenv \
+    grub_extraenv:/grub/grub_extraenv \
+    grub_extraenv:/EFI/BOOT/grub_extraenv \
     "
 
 write_mbr() {


### PR DESCRIPTION
This adds support for GRUB extra command line arguments using a grub_extraenv file in the boot partition