### PR TITLE
grub: Add recipe version 2.04 from Poky dunfell-23.0.1

### DIFF
--- a/layers/meta-balena-genericx86/conf/image-uefi.conf
+++ b/layers/meta-balena-genericx86/conf/image-uefi.conf
@@ -1,0 +1,16 @@
+# Location of EFI files inside EFI System Partition
+EFIDIR ?= "/EFI/BOOT"
+
+# Prefix where ESP is mounted inside rootfs. Set to empty if package is going
+# to be installed to ESP directly
+EFI_PREFIX ?= "/boot"
+
+# Location inside rootfs.
+EFI_FILES_PATH = "${EFI_PREFIX}${EFIDIR}"
+
+# Determine name of bootloader image
+EFI_BOOT_IMAGE ?= "bootINVALID.efi"
+EFI_BOOT_IMAGE_x86-64 = "bootx64.efi"
+EFI_BOOT_IMAGE_x86 = "bootia32.efi"
+EFI_BOOT_IMAGE_aarch64 = "bootaa64.efi"
+EFI_BOOT_IMAGE_arm = "bootarm.efi"

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/files/0001-Disable-mfpmath-sse-as-well-when-SSE-is-disabled.patch
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/files/0001-Disable-mfpmath-sse-as-well-when-SSE-is-disabled.patch
@@ -1,0 +1,43 @@
+From 96d9aa55d29b24e2490d5647a9efc66940fc400f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 13 Jan 2016 19:17:31 +0000
+Subject: [PATCH] Disable -mfpmath=sse as well when SSE is disabled
+
+Fixes
+
+configure:20574: i586-poky-linux-gcc  -m32    -march=core2 -msse3
+-mtune=generic -mfpmath=sse
+--sysroot=/usr/local/dev/yocto/grubtest2/build/tmp/sysroots/emenlow -o
+conftest -O2 -pipe -g -feliminate-unused-debug-types -Wall -W -Wshadow
+-Wpointer-arith -Wmissing-prototypes -Wundef -Wstrict-prototypes -g
+-falign-jumps=1 -falign-loops=1 -falign-functions=1 -mno-mmx -mno-sse
+-mno-sse2 -mno-3dnow -fno-dwarf2-cfi-asm -m32 -fno-stack-protector
+-mno-stack-arg-probe -Werror -nostdlib -Wl,--defsym,___main=0x8100
+-Wall -W -I$(top_srcdir)/include -I$(top_builddir)/include
+-DGRUB_MACHINE_PCBIOS=1 -DGRUB_MACHINE=I386_PC -Wl,-O1
+-Wl,--hash-style=gnu -Wl,--as-needed conftest.c  >&5
+conftest.c:1:0: error: SSE instruction set disabled, using 387
+arithmetics [-Werror]
+cc1: all warnings being treated as errors
+
+Signed-off-by: Nitin A Kamble <nitin.a.kamble@intel.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 7656f24..0868ea9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -824,7 +824,7 @@ fi
+ if ( test "x$target_cpu" = xi386 || test "x$target_cpu" = xx86_64 ) && test "x$platform" != xemu; then
+   # Some toolchains enable these features by default, but they need
+   # registers that aren't set up properly in GRUB.
+-  TARGET_CFLAGS="$TARGET_CFLAGS -mno-mmx -mno-sse -mno-sse2 -mno-sse3 -mno-3dnow"
++  TARGET_CFLAGS="$TARGET_CFLAGS -mno-mmx -mno-sse -mno-sse2 -mno-sse3 -mno-3dnow -mfpmath=387"
+ fi
+ 
+ # GRUB doesn't use float or doubles at all. Yet some toolchains may decide

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/files/0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/files/0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch
@@ -1,0 +1,54 @@
+From 8f47ed4aaefba087b6ca76e59c9f832b6a0702bc Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 13 Jan 2016 19:28:00 +0000
+Subject: [PATCH] grub.d/10_linux.in: add oe's kernel name
+
+Our kernel's name is bzImage, we need add it to grub.d/10_linux.in so
+that the grub-mkconfig and grub-install can work correctly.
+
+We only need add the bzImage to util/grub.d/10_linux.in, but also add it
+to util/grub.d/20_linux_xen.in to keep compatibility.
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Inappropriate [OE specific]
+
+---
+ util/grub.d/10_linux.in     | 6 +++---
+ util/grub.d/20_linux_xen.in | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
+index 4532266..cba2617 100644
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -164,12 +164,12 @@ machine=`uname -m`
+ case "x$machine" in
+     xi?86 | xx86_64)
+ 	list=
+-	for i in /boot/vmlinuz-* /vmlinuz-* /boot/kernel-* ; do
++	for i in /boot/bzImage-* /bzImage-* /boot/vmlinuz-* /vmlinuz-* /boot/kernel-* ; do
+ 	    if grub_file_is_not_garbage "$i" ; then list="$list $i" ; fi
+ 	done ;;
+-    *) 
++    *)
+ 	list=
+-	for i in /boot/vmlinuz-* /boot/vmlinux-* /vmlinuz-* /vmlinux-* /boot/kernel-* ; do
++	for i in /boot/bzImage-* /boot/vmlinuz-* /boot/vmlinux-* /bzImage-* /vmlinuz-* /vmlinux-* /boot/kernel-* ; do
+                   if grub_file_is_not_garbage "$i" ; then list="$list $i" ; fi
+ 	done ;;
+ esac
+diff --git a/util/grub.d/20_linux_xen.in b/util/grub.d/20_linux_xen.in
+index 96179ea..98d16ae 100644
+--- a/util/grub.d/20_linux_xen.in
++++ b/util/grub.d/20_linux_xen.in
+@@ -154,7 +154,7 @@ EOF
+ }
+ 
+ linux_list=
+-for i in /boot/vmlinu[xz]-* /vmlinu[xz]-* /boot/kernel-*; do
++for i in /boot/bzImage[xz]-* /bzImage[xz]-* /boot/vmlinu[xz]-* /vmlinu[xz]-* /boot/kernel-*; do
+     if grub_file_is_not_garbage "$i"; then
+     	basename=$(basename $i)
+ 	version=$(echo $basename | sed -e "s,^[^0-9]*-,,g")

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/files/autogen.sh-exclude-pc.patch
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/files/autogen.sh-exclude-pc.patch
@@ -1,0 +1,35 @@
+From 72c30928d3d461e0e2d20c5ff33bd96b6991d585 Mon Sep 17 00:00:00 2001
+From: Robert Yang <liezhi.yang@windriver.com>
+Date: Sat, 25 Jan 2014 23:49:44 -0500
+Subject: [PATCH] autogen.sh: exclude .pc from po/POTFILES.in
+
+Exclude the .pc from po/POTFILES.in since quilt uses "patch --backup",
+which will create the backup file under .pc, this may cause unexpected
+errors, for example, on CentOS 5.x, if the backup file is null
+(newfile), it's mode will be 000, then we will get errors when xgettext
+try to read it.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ autogen.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index ef43270..a7067a7 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -13,7 +13,7 @@ fi
+ export LC_COLLATE=C
+ unset LC_ALL
+ 
+-find . -iname '*.[ch]' ! -ipath './grub-core/lib/libgcrypt-grub/*' ! -ipath './build-aux/*' ! -ipath './grub-core/lib/libgcrypt/src/misc.c' ! -ipath './grub-core/lib/libgcrypt/src/global.c' ! -ipath './grub-core/lib/libgcrypt/src/secmem.c'  ! -ipath './util/grub-gen-widthspec.c' ! -ipath './util/grub-gen-asciih.c' ! -ipath './gnulib/*' ! -iname './grub-core/lib/gnulib/*' |sort > po/POTFILES.in
++find . -iname '*.[ch]' ! -ipath './grub-core/lib/libgcrypt-grub/*' ! -ipath './build-aux/*' ! -ipath './grub-core/lib/libgcrypt/src/misc.c' ! -ipath './grub-core/lib/libgcrypt/src/global.c' ! -ipath './grub-core/lib/libgcrypt/src/secmem.c'  ! -ipath './util/grub-gen-widthspec.c' ! -ipath './util/grub-gen-asciih.c' ! -ipath './gnulib/*' ! -iname './grub-core/lib/gnulib/*' ! -path './.pc/*' |sort > po/POTFILES.in
+ find util -iname '*.in' ! -name Makefile.in  |sort > po/POTFILES-shell.in
+ 
+ echo "Importing unicode..."
+-- 
+2.7.4
+

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/files/cfg
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/files/cfg
@@ -1,0 +1,2 @@
+search.file ($cmdpath)/EFI/BOOT/grub.cfg root
+set prefix=($root)/EFI/BOOT

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/files/grub-module-explicitly-keeps-symbole-.module_license.patch
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/files/grub-module-explicitly-keeps-symbole-.module_license.patch
@@ -1,0 +1,59 @@
+From 917133acc701dbc4636165d3b08d15dc5829a06f Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Wed, 17 Aug 2016 04:06:34 -0400
+Subject: [PATCH] grub module explicitly keeps symbole .module_license
+
+While using oe-core toolchain to strip grub module 'all_video.mod',
+it stripped symbol table:
+
+---------------
+root@localhost:~# objdump -t all_video.mod
+ 
+all_video.mod:     file format elf64-x86-64
+
+SYMBOL TABLE:
+no symbols
+--------------
+
+It caused grub to load module all_video failed.
+--------------
+grub> insmod all_video
+error: no symbol table.
+--------------
+
+Tweak strip option to keep symbol .module_license could workaround
+the issue.
+--------------
+root@localhost:~# objdump -t all_video.mod
+
+all_video.mod:     file format elf64-x86-64
+
+SYMBOL TABLE:
+0000000000000000 l    d  .text  0000000000000000 .text
+0000000000000000 l    d  .data  0000000000000000 .data
+0000000000000000 l    d  .module_license        0000000000000000 .module_license
+0000000000000000 l    d  .bss   0000000000000000 .bss
+0000000000000000 l    d  .moddeps       0000000000000000 .moddeps
+0000000000000000 l    d  .modname       0000000000000000 .modname
+--------------
+
+Upstream-Status: Pending
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ grub-core/genmod.sh.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/genmod.sh.in b/grub-core/genmod.sh.in
+index 1250589..dd14308 100644
+--- a/grub-core/genmod.sh.in
++++ b/grub-core/genmod.sh.in
+@@ -56,7 +56,7 @@ if test x@TARGET_APPLE_LINKER@ != x1; then
+ 	if test x@platform@ != xemu; then
+ 	    @TARGET_STRIP@ --strip-unneeded \
+ 		-K grub_mod_init -K grub_mod_fini \
+-		-K _grub_mod_init -K _grub_mod_fini \
++		-K _grub_mod_init -K _grub_mod_fini -K .module_license \
+ 		-R .note.gnu.gold-version -R .note.GNU-stack \
+ 		-R .gnu.build.attributes \
+ 		-R .rel.gnu.build.attributes \

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/grub-bootconf_1.00.bb
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/grub-bootconf_1.00.bb
@@ -1,0 +1,32 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+SUMMARY = "Basic grub.cfg for use in EFI systems"
+DESCRIPTION = "Grub might require different configuration file for \
+different machines."
+HOMEPAGE = "https://www.gnu.org/software/grub/manual/grub/grub.html#Configuration"
+
+RPROVIDES_${PN} += "virtual/grub-bootconf"
+
+inherit grub-efi-cfg
+
+require conf/image-uefi.conf
+
+S = "${WORKDIR}"
+
+GRUB_CFG = "${S}/grub-bootconf"
+LABELS = "boot"
+
+ROOT ?= "root=/dev/sda2"
+
+python do_configure() {
+    bb.build.exec_func('build_efi_cfg', d)
+}
+
+do_configure[vardeps] += "APPEND ROOT"
+
+do_install() {
+	install -d ${D}${EFI_FILES_PATH}
+	install grub-bootconf ${D}${EFI_FILES_PATH}/grub.cfg
+}
+
+FILES_${PN} = "${EFI_FILES_PATH}/grub.cfg"

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/grub-efi_2.04.bb
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/grub-efi_2.04.bb
@@ -1,0 +1,109 @@
+require grub2.inc
+
+require conf/image-uefi.conf
+
+GRUBPLATFORM = "efi"
+
+DEPENDS_append_class-target = " grub-efi-native"
+RDEPENDS_${PN}_class-target = "grub-common virtual/grub-bootconf"
+
+SRC_URI += " \
+           file://cfg \
+          "
+
+S = "${WORKDIR}/grub-${PV}"
+
+# Determine the target arch for the grub modules
+python __anonymous () {
+    import re
+    target = d.getVar('TARGET_ARCH')
+    prefix = "" if d.getVar('EFI_PROVIDER') == "grub-efi" else "grub-efi-"
+    if target == "x86_64":
+        grubtarget = 'x86_64'
+    elif re.match('i.86', target):
+        grubtarget = 'i386'
+    elif re.match('aarch64', target):
+        grubtarget = 'arm64'
+    elif re.match('arm', target):
+        grubtarget = 'arm'
+    else:
+        raise bb.parse.SkipRecipe("grub-efi is incompatible with target %s" % target)
+    grubimage = prefix + d.getVar("EFI_BOOT_IMAGE")
+    d.setVar("GRUB_TARGET", grubtarget)
+    d.setVar("GRUB_IMAGE", grubimage)
+    prefix = "grub-efi-" if prefix == "" else ""
+    d.setVar("GRUB_IMAGE_PREFIX", prefix)
+}
+
+inherit deploy
+
+CACHED_CONFIGUREVARS += "ac_cv_path_HELP2MAN="
+EXTRA_OECONF += "--enable-efiemu=no"
+
+do_mkimage() {
+	cd ${B}
+	# Search for the grub.cfg on the local boot media by using the
+	# built in cfg file provided via this recipe
+	grub-mkimage -c ../cfg -p ${EFIDIR} -d ./grub-core/ \
+	               -O ${GRUB_TARGET}-efi -o ./${GRUB_IMAGE_PREFIX}${GRUB_IMAGE} \
+	               ${GRUB_BUILDIN}
+}
+
+addtask mkimage before do_install after do_compile
+
+do_mkimage_class-native() {
+	:
+}
+
+do_install_append_class-target() {
+	install -d ${D}${EFI_FILES_PATH}
+	install -m 644 ${B}/${GRUB_IMAGE_PREFIX}${GRUB_IMAGE} ${D}${EFI_FILES_PATH}/${GRUB_IMAGE}
+}
+
+do_install_class-native() {
+	install -d ${D}${bindir}
+	install -m 755 grub-mkimage ${D}${bindir}
+	install -m 755 grub-editenv ${D}${bindir}
+}
+
+do_install_class-target() {
+    oe_runmake 'DESTDIR=${D}' -C grub-core install
+
+    # Remove build host references...
+    find "${D}" -name modinfo.sh -type f -exec \
+        sed -i \
+        -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
+        -e 's|${DEBUG_PREFIX_MAP}||g' \
+        -e 's:${RECIPE_SYSROOT_NATIVE}::g' \
+        {} +
+}
+
+do_install_append_aarch64() {
+    rm -rf  ${D}/${prefix}/
+}
+
+GRUB_BUILDIN ?= "boot linux ext2 fat serial part_msdos part_gpt normal \
+                 efi_gop iso9660 configfile search loadenv test"
+
+do_deploy() {
+	install -m 644 ${B}/${GRUB_IMAGE_PREFIX}${GRUB_IMAGE} ${DEPLOYDIR}
+}
+
+do_deploy_class-native() {
+	:
+}
+
+addtask deploy after do_install before do_build
+
+FILES_${PN} = "${libdir}/grub/${GRUB_TARGET}-efi \
+               ${datadir}/grub \
+               ${EFI_FILES_PATH}/${GRUB_IMAGE} \
+               "
+
+FILES_${PN}_remove_aarch64 = "${libdir}/grub/${GRUB_TARGET}-efi"
+
+# 64-bit binaries are expected for the bootloader with an x32 userland
+INSANE_SKIP_${PN}_append_linux-gnux32 = " arch"
+INSANE_SKIP_${PN}-dbg_append_linux-gnux32 = " arch"
+INSANE_SKIP_${PN}_append_linux-muslx32 = " arch"
+INSANE_SKIP_${PN}-dbg_append_linux-muslx32 = " arch"

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/grub2.inc
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/grub2.inc
@@ -1,0 +1,70 @@
+SUMMARY = "GRUB2 is the next-generation GRand Unified Bootloader"
+
+DESCRIPTION = "GRUB2 is the next generaion of a GPLed bootloader \
+intended to unify bootloading across x86 operating systems. In \
+addition to loading the Linux kernel, it implements the Multiboot \
+standard, which allows for flexible loading of multiple boot images."
+
+HOMEPAGE = "http://www.gnu.org/software/grub/"
+SECTION = "bootloaders"
+
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
+
+SRC_URI = "${GNU_MIRROR}/grub/grub-${PV}.tar.gz \
+           file://0001-Disable-mfpmath-sse-as-well-when-SSE-is-disabled.patch \
+           file://autogen.sh-exclude-pc.patch \
+           file://grub-module-explicitly-keeps-symbole-.module_license.patch \
+           file://0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch \
+"
+SRC_URI[md5sum] = "5ce674ca6b2612d8939b9e6abed32934"
+SRC_URI[sha256sum] = "f10c85ae3e204dbaec39ae22fa3c5e99f0665417e91c2cb49b7e5031658ba6ea"
+
+DEPENDS = "flex-native bison-native gettext-native"
+
+COMPATIBLE_HOST = '(x86_64.*|i.86.*|arm.*|aarch64.*)-(linux.*|freebsd.*)'
+COMPATIBLE_HOST_armv7a = 'null'
+COMPATIBLE_HOST_armv7ve = 'null'
+
+# configure.ac has code to set this automagically from the target tuple
+# but the OE freeform one (core2-foo-bar-linux) don't work with that.
+
+GRUBPLATFORM_arm = "efi"
+GRUBPLATFORM_aarch64 = "efi"
+GRUBPLATFORM ??= "pc"
+
+inherit autotools gettext texinfo pkgconfig
+
+EXTRA_OECONF = "--with-platform=${GRUBPLATFORM} \
+                --disable-grub-mkfont \
+                --program-prefix="" \
+                --enable-liblzma=no \
+                --enable-libzfs=no \
+                --enable-largefile \
+                --disable-werror \
+"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[grub-mount] = "--enable-grub-mount,--disable-grub-mount,fuse"
+PACKAGECONFIG[device-mapper] = "--enable-device-mapper,--disable-device-mapper,libdevmapper"
+
+# grub2 creates its own set of -nostdinc / -isystem / -ffreestanding CFLAGS and
+# OE's default BUILD_CFLAGS (assigned to CFLAGS for native builds) etc, conflict
+# with that. Note that since BUILD_CFLAGS etc are not used by grub2 target
+# builds, it's safe to clear them unconditionally for both target and native.
+BUILD_CPPFLAGS = ""
+BUILD_CFLAGS = ""
+BUILD_CXXFLAGS = ""
+BUILD_LDFLAGS = ""
+
+export PYTHON = "python3"
+
+do_configure_prepend() {
+	cd ${S}
+	FROM_BOOTSTRAP=1 ${S}/autogen.sh
+	cd ${B}
+}
+
+RDEPENDS_${PN}_class-native = ""
+
+BBCLASSEXTEND = "native"

--- a/layers/meta-balena-genericx86/recipes-bsp/grub/grub_2.04.bb
+++ b/layers/meta-balena-genericx86/recipes-bsp/grub/grub_2.04.bb
@@ -1,0 +1,33 @@
+require grub2.inc
+
+RDEPENDS_${PN}-common += "${PN}-editenv"
+RDEPENDS_${PN} += "${PN}-common"
+
+RPROVIDES_${PN}-editenv += "${PN}-efi-editenv"
+
+PACKAGES =+ "${PN}-editenv ${PN}-common"
+FILES_${PN}-editenv = "${bindir}/grub-editenv"
+FILES_${PN}-common = " \
+    ${bindir} \
+    ${sysconfdir} \
+    ${sbindir} \
+    ${datadir}/grub \
+"
+
+FILES_${PN}-common_append_aarch64 = " \
+    ${libdir}/${BPN} \
+"
+
+do_install_append () {
+    install -d ${D}${sysconfdir}/grub.d
+    # Remove build host references...
+    find "${D}" -name modinfo.sh -type f -exec \
+        sed -i \
+        -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
+        -e 's|${DEBUG_PREFIX_MAP}||g' \
+        -e 's:${RECIPE_SYSROOT_NATIVE}::g' \
+        {} +
+}
+
+INSANE_SKIP_${PN} = "arch"
+INSANE_SKIP_${PN}-dbg = "arch"


### PR DESCRIPTION
Until we support dunfell-23.0.1 we need to use a newer grub version 2.04
needed for example by Dell Latitude 7220 Rugged Extreme Tablet.

Changelog-entry: Update to grub 2.04 taken from Poky dunfell-23.0.1
Signed-off-by: Florin Sarbu <florin@balena.io>