### PR TITLE
resin-init-board: Add Surface Go LTE modem initialization

### DIFF
--- a/layers/meta-balena-genericx86/recipes-support/resin-init/resin-init-board.bbappend
+++ b/layers/meta-balena-genericx86/recipes-support/resin-init/resin-init-board.bbappend
@@ -1,1 +1,13 @@
 FILESEXTRAPATHS_append := "${THISDIR}/${PN}"
+
+SRC_URI_append_surface-go = " \
+			file://surface-go-init-board \
+"
+
+# Adds LTE Modem initialization sequence for the Surface Go
+# See: https://github.com/jakeday/linux-surface/issues/306#issuecomment-518898603
+do_install_append_surface-go() {
+    cat ${WORKDIR}/resin-init-board | grep -v "exit 0" > ${D}${bindir}/resin-init-board
+    cat ${WORKDIR}/surface-go-init-board >> ${D}${bindir}/resin-init-board
+    echo "exit 0"  >> ${D}${bindir}/resin-init-board
+}

--- a/layers/meta-balena-genericx86/recipes-support/resin-init/resin-init-board/surface-go-init-board
+++ b/layers/meta-balena-genericx86/recipes-support/resin-init/resin-init-board/surface-go-init-board
@@ -1,0 +1,9 @@
+cdc_ncm_rx_max=$(find /sys/devices/ | grep usb | grep wwp0s | grep cdc_ncm | grep rx_max | head -n 1)
+cdc_ncm_tx_max=$(find /sys/devices/ | grep usb | grep wwp0s | grep cdc_ncm | grep tx_max | head -n 1)
+
+# By default tx and rx max values are 16384
+if [[ -f ${cdc_ncm_rx_max} && -f ${cdc_ncm_tx_max} ]]; then
+    echo 16383 | tee ${cdc_ncm_rx_max} ${cdc_ncm_tx_max}
+    echo 16384 | tee ${cdc_ncm_rx_max} ${cdc_ncm_tx_max}
+fi
+


### PR DESCRIPTION
This adds the steps for initializing the LTE modem
on the Surface Go tablet. By default rx_max and tx_max
are 16384, however this sequence is needed to bring
up the modem.

Changelog-entry: resin-init-board: Add Surface Go LTE modem initialization
Signed-off-by: Alexandru Costache <alexandru@balena.io>