### PR TITLE
genericx86-64: add ath10k driver with support for QCA9377

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -15,6 +15,10 @@ CONNECTIVITY_FIRMWARES =+ " \
 	linux-firmware-ralink-nic \
 	"
 
+CONNECTIVITY_FIRMWARES_append_genericx86-64 = " \
+    linux-firmware-ath10k \
+"
+
 CONNECTIVITY_FIRMWARES_append_surface-go = " \
 	linux-firmware-ath10k-qca6174 \
 	linux-firmware-i915-kbl \


### PR DESCRIPTION
Connects-to: https://github.com/balena-os/balena-intel/issues/353
Change-type: patch
Changelog-entry: add ath10k driver to Intel NUC
Signed-off-by: Kyle Harding <kyle@balena.io>