### PR TITLE
genericx86-64-ext: Add support for aufs in addition to overlay2

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-resin.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-resin.bbappend
@@ -1,3 +1,8 @@
 RDEPENDS_${PN}_append_surface-go = " \
     linux-firmware-ipu3-firmware \
 "
+
+# install aufs support even when BALENA_STORAGE is overlay2
+RDEPENDS_${PN}_append_genericx86-64-ext = " \
+    aufs-util-auplink \
+"

--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -196,6 +196,9 @@ RESIN_CONFIGS_remove_surface-pro-6 = "overlayfs"
 RESIN_CONFIGS_remove_surface-go = "overlayfs"
 RESIN_CONFIGS_remove_genericx86-64-ext = "overlayfs"
 
+# install aufs support even when BALENA_STORAGE is overlay2
+RESIN_CONFIGS_append_genericx86-64-ext = " aufs"
+
 # Add CAN support (requested by customer)
 RESIN_CONFIGS_append = " enable_can"
 RESIN_CONFIGS[enable_can] = " \


### PR DESCRIPTION
Add support for aufs in addition to overlay2 for Generic x86-64

Depends-on: https://github.com/balena-os/meta-balena/pull/2132
Changelog-entry: Add support for aufs in addition to overlay2 for Generic x86-64
Signed-off-by: Kyle Harding <kyle@balena.io>