### PR TITLE
linux-firmware: Include firmware for AX200NGW and AX201NGW WiFi 6 adapters

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -3,12 +3,16 @@ CONNECTIVITY_FIRMWARES =+ " \
 	linux-firmware-ibt-11-5 \
 	linux-firmware-ibt-12-16 \
 	linux-firmware-ibt-18-16-1 \
+	linux-firmware-ibt-19-0-4 \
+	linux-firmware-ibt-20-1-3 \
 	linux-firmware-ibt-hw-37-7 \
 	linux-firmware-ibt-hw-37-8 \
 	linux-firmware-iwlwifi-3168 \
 	linux-firmware-iwlwifi-9000 \
 	linux-firmware-iwlwifi-9260 \
+	linux-firmware-iwlwifi-cc-a0 \
 	linux-firmware-iwlwifi-qu-b0-hr-b0 \
+	linux-firmware-iwlwifi-quz-a0-hr-b0 \
 	linux-firmware-rtl8723 \
 	linux-firmware-rtl8821 \
 	linux-firmware-rtl8723b-bt \
@@ -23,8 +27,6 @@ CONNECTIVITY_FIRMWARES:append:genericx86-64 = " \
 CONNECTIVITY_FIRMWARES:append:surface-go = " \
 	linux-firmware-ath10k-qca6174 \
 	linux-firmware-i915-kbl \
-	linux-firmware-iwlwifi-cc-a0 \
-	linux-firmware-ibt-20-1-3 \
 "
 
 CONNECTIVITY_FIRMWARES:append:surface-pro-6 = " \
@@ -40,6 +42,7 @@ CONNECTIVITY_FIRMWARES:remove_surface-go = " \
     linux-firmware-ibt-11-5 \
     linux-firmware-ibt-12-16 \
     linux-firmware-ibt-18-16-1 \
+    linux-firmware-ibt-19-0-4 \
     linux-firmware-ibt-hw-37-7 \
     linux-firmware-ibt-hw-37-8 \
     linux-firmware-iwlwifi-3168 \


### PR DESCRIPTION
The PR depends on https://github.com/balena-os/meta-balena/pull/2239

These adapters are on 10th and 11th gen NUCs, recent laptops and also available as standalone M.2 cards.

- AX200NGW: iwlwifi-cc-a0 and ibt-20-1-3
- AX201NGW: iwlwifi-quz-a0-hr-b0 and ibt-19-0-4

Changelog-entry: Include firmware for AX200NGW and AX201NGW WiFi 6 adapters
Signed-off-by: Michal Toman <michalt@balena.io>