### PR TITLE
linux-firmware: use upstream for ath10k/QCA6174

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -6,10 +6,7 @@ SRC_URI += " \
     file://SurfaceTouchServicingKernelMSHW0102.bin.sig \
     file://SurfaceTouchServicingSFTConfigMSHW0102.bin \
     file://SurfaceTouchServicingTouchBlobMSHW0102.bin \
-    file://board-2.bin \
-    file://board.bin \
     file://config.bin \
-    file://firmware-6.bin \
     file://iaPreciseTouchDescriptor.bin \
     file://intel_desc.bin \
     file://ipts_fw_config.bin \
@@ -55,9 +52,6 @@ FILES_${PN}-iwlwifi-quz-a0-hr-b0 = " \
 do_install_append() {
     install -d ${D}${nonarch_base_libdir}/firmware/brcm/
     install -m 0644 ${WORKDIR}/raspbian-nf/brcm/brcmfmac43455-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/
-
-    install -d ${D}${nonarch_base_libdir}/firmware/ath10k/QCA6174/hw3.0/
-    install -m 0644 ${WORKDIR}/board-2.bin ${WORKDIR}/board.bin ${WORKDIR}/firmware-6.bin ${D}${nonarch_base_libdir}/firmware/ath10k/QCA6174/hw3.0/
 
     install -d ${D}${nonarch_base_libdir}/firmware/intel/ipts/
     install -m 0644 ${WORKDIR}/SurfaceTouchServicingDescriptorMSHW0102.bin \


### PR DESCRIPTION
Upstream firmware is now compatible with the Surface Go, and the old
firmware is incompatible with other common devices. Default to the
upstream firmware to resolve these issues.

This reverts commit d50848e

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>

This branch requires the linux-firmware-20210511 PR from meta-balena: https://github.com/balena-os/meta-balena/pull/2240