### PR TITLE
linux-firmware: Package iwlwifi-QuZ-a0-hr-b0 firmware

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -14,6 +14,9 @@ CONNECTIVITY_FIRMWARES =+ " \
 	linux-firmware-rtl8723b-bt \
 	linux-firmware-ralink-nic \
 	"
+CONNECTIVITY_FIRMWARES_append_genericx86-64 = " \
+	linux-firmware-iwlwifi-quz-a0-hr-b0 \
+"
 
 CONNECTIVITY_FIRMWARES_append_surface-go = " \
 	linux-firmware-ath10k-qca6174 \

--- a/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -46,6 +46,12 @@ FILES_${PN}-ipu3-firmware = " \
     ${nonarch_base_libdir}/firmware/LICENSE.ipu3_firmware \
 "
 
+PACKAGES =+ "${PN}-iwlwifi-quz-a0-hr-b0"
+
+FILES_${PN}-iwlwifi-quz-a0-hr-b0 = " \
+    ${nonarch_base_libdir}/firmware/iwlwifi-QuZ-a0-hr-b0-48.ucode \
+"
+
 do_install_append() {
     install -d ${D}${nonarch_base_libdir}/firmware/brcm/
     install -m 0644 ${WORKDIR}/raspbian-nf/brcm/brcmfmac43455-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/


### PR DESCRIPTION
We add this fw on its own package so that boards can add it to
rootfs (for Intel NUC 11th generation more specifically)

Changelog-entry: Package iwlwifi-QuZ-a0-hr-b0 firmware separately
Signed-off-by: Florin Sarbu <florin@balena.io>