### PR TITLE
smartcube: Remove reference to these obsolete machines

### DIFF
--- a/layers/meta-balena-genericx86/conf/machine/smartcube-kbox-a150.conf
+++ b/layers/meta-balena-genericx86/conf/machine/smartcube-kbox-a150.conf
@@ -1,8 +1,0 @@
-#@TYPE: Machine
-##@NAME: smartcube-kbox-a150
-##@DESCRIPTION: Machine configuration for smartcube-kbox-a150 based on the extra configured genericx86-64 device
-
-MACHINEOVERRIDES = "genericx86-64-ext:${MACHINE}"
-include conf/machine/genericx86-64.conf
-
-PREFERRED_PROVIDER_virtual/kernel = "linux-yocto-rt"

--- a/layers/meta-balena-genericx86/conf/machine/smartcube-kbox-a250.conf
+++ b/layers/meta-balena-genericx86/conf/machine/smartcube-kbox-a250.conf
@@ -1,6 +1,0 @@
-#@TYPE: Machine
-##@NAME: smartcube-kbox-a250
-##@DESCRIPTION: Machine configuration for smartcube-kbox-a250 based on the extra configured genericx86-64 device
-
-MACHINEOVERRIDES = "genericx86-64-ext:${MACHINE}"
-include conf/machine/genericx86-64.conf

--- a/layers/meta-balena-genericx86/conf/samples/local.conf.sample
+++ b/layers/meta-balena-genericx86/conf/samples/local.conf.sample
@@ -1,13 +1,9 @@
 # Supported machines
 #MACHINE ?= "genericx86-64"
 #MACHINE ?= "genericx86-64-ext"
-#MACHINE ?= "smartcube-kbox-a150"
-#MACHINE ?= "smartcube-kbox-a250"
 #MACHINE ?= "surface-go"
 #MACHINE ?= "surface-pro-6"
 
-BALENA_STORAGE_smartcube-kbox-a150 = "overlay2"
-BALENA_STORAGE_smartcube-kbox-a250 = "overlay2"
 BALENA_STORAGE_surface-pro-6 = "overlay2"
 BALENA_STORAGE_surface-go = "overlay2"
 BALENA_STORAGE_genericx86-64-ext = "overlay2"

--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -23,8 +23,6 @@ do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}binutils:do_populate_sys
 do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
 do_kernel_configme[depends] += "bc-native:do_populate_sysroot bison-native:do_populate_sysroot"
 
-COMPATIBLE_MACHINE_smartcube-kbox-a250 = "smartcube-kbox-a250"
-
 BALENA_CONFIGS_append_surface-go = " sgo2_camera"
 BALENA_CONFIGS[sgo2_camera] = " \
     CONFIG_MEMSTICK=m \


### PR DESCRIPTION
The customer that requested these device types never really used them so
let's remove all references to them from here.

Changelog-entry: Remove references to unused Smartcube device types
Signed-off-by: Florin Sarbu <florin@balena.io>