### PR TITLE
add linux-firmware-ath10k-qca6174 to connectivity firmware

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -13,6 +13,7 @@ CONNECTIVITY_FIRMWARES =+ " \
 	linux-firmware-rtl8821 \
 	linux-firmware-rtl8723b-bt \
 	linux-firmware-ralink-nic \
+	linux-firmware-ath10k-qca6174 \
 	"
 CONNECTIVITY_FIRMWARES_append_genericx86-64 = " \
 	linux-firmware-ibt-19-0-4 \


### PR DESCRIPTION
This installs upstream firmware for the QCA6174 802.11ac adapter.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>