### PR TITLE
Revert "genericx86-64-ext: Publish both flasher and raw images"

### DIFF
--- a/genericx86-64-ext.coffee
+++ b/genericx86-64-ext.coffee
@@ -46,8 +46,7 @@ module.exports =
 		image: 'balena-image-flasher'
 		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'balena-image-genericx86-64-ext.balenaos-img'
-		deployFlasherArtifact: 'balena-image-flasher-genericx86-64-ext.balenaos-img'
+		deployArtifact: 'balena-image-flasher-genericx86-64-ext.balenaos-img'
 		compressed: true
 
 	configuration:


### PR DESCRIPTION
Reverts balena-os/balena-intel#414

Reverting this for now until we have the full solution ready. We don't want to accidentally publish the non-flasher images early.

Improvement: https://jel.ly.fish/improvement-expose-flasher-raw-images-dashboard-generic-dts-90f2f44