### PR TITLE
genericx86-64-ext: deploy flasher artifact

### DIFF
--- a/genericx86-64-ext.coffee
+++ b/genericx86-64-ext.coffee
@@ -47,6 +47,7 @@ module.exports =
 		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
 		deployArtifact: 'balena-image-flasher-genericx86-64-ext.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-genericx86-64-ext.balenaos-img'
 		compressed: true
 
 	configuration:


### PR DESCRIPTION
We'd like to deploy both flasher and non-flasher images, but currently,
balena.img is a flasher image always. Upload the flasher image at a
different path to allow us to wire up separately denoted flasher images
before we replace balena.img with a non-flasher image.

Change-type: patch
Changelog-entry: Deploy flasher artifact for genericx86-64-ext
Signed-off-by: Joseph Kogut <joseph@balena.io>