### PR TITLE
Rename `DEVELOPMENT_IMAGE` flag to `OS_DEVELOPMENT` 

### DIFF
--- a/layers/meta-balena-genericx86/conf/samples/local.conf.sample
+++ b/layers/meta-balena-genericx86/conf/samples/local.conf.sample
@@ -9,7 +9,7 @@
 #TARGET_TAG ?= ""
 
 # Set this to 1 if development image is desired
-#DEVELOPMENT_IMAGE = "1"
+#OS_DEVELOPMENT = "1"
 
 # Set this to make build system generate resinhup bundles
 #RESINHUP ?= "yes"


### PR DESCRIPTION
There are two reasons for this patch:

1. The current flag is incorrect, see https://github.com/balena-os/meta-balena/blob/master/README.md#os-development
2. The `barys` script will not work when `--development` is used, see https://github.com/balena-os/balena-yocto-scripts/blob/master/build/barys#L449 and https://github.com/balena-os/balena-yocto-scripts/issues/251