### PR TITLE
genericx86-64-ext: add raw and flasher artifacts

### DIFF
--- a/genericx86-64-ext.coffee
+++ b/genericx86-64-ext.coffee
@@ -47,6 +47,8 @@ module.exports =
 		fstype: 'balenaos-img'
 		version: 'yocto-honister'
 		deployArtifact: 'balena-image-flasher-genericx86-64-ext.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-genericx86-64-ext.balenaos-img'
+		deployRawArtifact: 'balena-image-genericx86-64-ext.balenaos-img'
 		compressed: true
 
 	configuration:


### PR DESCRIPTION
Now that balena-yocto-scripts support uploading named artifacts, upload
raw and flasher images for genericx86-64-ext.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>