### PR TITLE
linux-firmware: Move iwlwifi-quz-a0-hr-b0 to meta-balena

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -43,12 +43,6 @@ FILES:${PN}-ipu3-firmware = " \
     ${nonarch_base_libdir}/firmware/LICENSE.ipu3_firmware* \
 "
 
-PACKAGES =+ "${PN}-iwlwifi-quz-a0-hr-b0"
-
-FILES:${PN}-iwlwifi-quz-a0-hr-b0 = " \
-    ${nonarch_base_libdir}/firmware/iwlwifi-QuZ-a0-hr-b0-48.ucode* \
-"
-
 do_install:append() {
     install -d ${D}${nonarch_base_libdir}/firmware/brcm/
     install -m 0644 ${WORKDIR}/raspbian-nf/brcm/brcmfmac43455-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/


### PR DESCRIPTION
This allows the package to be used by other device types.

The corresponding meta-balena change is https://github.com/balena-os/meta-balena/pull/2239/files

Changelog-entry: Move iwlwifi-quz-a0-hr-b0 firmware to meta-balena
Signed-off-by: Alex Gonzalez <alexg@balena.io>