### PR TITLE
packagegroup-balena-connectivity: Remove redundant linux-firmware-iwl…

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -21,7 +21,6 @@ CONNECTIVITY_FIRMWARES =+ " \
 	"
 CONNECTIVITY_FIRMWARES:append:genericx86-64 = " \
 	linux-firmware-ibt-19-0-4 \
-	linux-firmware-iwlwifi-quz-a0-hr-b0 \
 "
 
 CONNECTIVITY_FIRMWARES:append:surface-go = " \


### PR DESCRIPTION
…wifi-quz-a0-hr-b0

This package is already included by default.

Changelog-entry: Remove redundant linux-firmware-iwlwifi-quz-a0-hr-b0
Signed-off-by: Alex Gonzalez <alexg@balena.io>