### PR TITLE
packagegroup-balena-connectivity: Remove redundant linux-firmware-iwlwifi-quz-a0-hr-b0

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -12,7 +12,6 @@ CONNECTIVITY_FIRMWARES =+ " \
 	linux-firmware-iwlwifi-9260 \
 	linux-firmware-iwlwifi-cc-a0 \
 	linux-firmware-iwlwifi-qu-b0-hr-b0 \
-	linux-firmware-iwlwifi-quz-a0-hr-b0 \
 	linux-firmware-rtl8723 \
 	linux-firmware-rtl8821 \
 	linux-firmware-rtl8723b-bt \
@@ -21,7 +20,6 @@ CONNECTIVITY_FIRMWARES =+ " \
 	"
 CONNECTIVITY_FIRMWARES:append:genericx86-64 = " \
 	linux-firmware-ibt-19-0-4 \
-	linux-firmware-iwlwifi-quz-a0-hr-b0 \
 "
 
 CONNECTIVITY_FIRMWARES:append:surface-go = " \


### PR DESCRIPTION
This is necessary to unwind a circular dependency moving the package to meta-balena