### PR TITLE
balena-connectivity: Include iwlwifi-quz-a0-hr-b0 and iwlwifi-quz-a0-jf-b0

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -12,6 +12,8 @@ CONNECTIVITY_FIRMWARES =+ " \
 	linux-firmware-iwlwifi-9260 \
 	linux-firmware-iwlwifi-cc-a0 \
 	linux-firmware-iwlwifi-qu-b0-hr-b0 \
+	linux-firmware-iwlwifi-quz-a0-hr-b0 \
+	linux-firmware-iwlwifi-quz-a0-jf-b0 \
 	linux-firmware-rtl8723 \
 	linux-firmware-rtl8821 \
 	linux-firmware-rtl8723b-bt \
@@ -84,6 +86,8 @@ CONNECTIVITY_FIRMWARES:remove:surface-pro-6 = " \
     linux-firmware-iwlwifi-9000 \
     linux-firmware-iwlwifi-9260 \
     linux-firmware-iwlwifi-qu-b0-hr-b0 \
+    linux-firmware-iwlwifi-quz-a0-hr-b0 \
+    linux-firmware-iwlwifi-quz-a0-jf-b0 \
     linux-firmware-pcie8897 \
     linux-firmware-rtl8723 \
     linux-firmware-rtl8821 \
@@ -107,6 +111,11 @@ CONNECTIVITY_FIRMWARES:remove:surface-pro-6 = " \
     linux-firmware-iwlwifi-8265 \
     linux-firmware-rtl8188eu \
     linux-firmware-wl18xx \
+"
+
+CONNECTIVITY_FIRMWARES:remove_surface-pro-6 = " \
+    linux-firmware-iwlwifi-quz-a0-hr-b0 \
+    linux-firmware-iwlwifi-quz-a0-jf-b0 \
 "
 
 # these are now just empty packages so let's remove them to avoid a build error


### PR DESCRIPTION
These are used for AX201NGW and AC9462 respectively, available on 11th gen NUCs as well as standalone M.2 cards.

Depends-on: https://github.com/balena-os/balena-intel/pull/532