### PR TITLE
linux-yocto: Use kernel 5.14

### DIFF
--- a/layers/meta-balena-genericx86/conf/layer.conf
+++ b/layers/meta-balena-genericx86/conf/layer.conf
@@ -8,3 +8,6 @@ BBFILE_PATTERN_balena-genericx86 := "^${LAYERDIR}/"
 BBFILE_PRIORITY_balena-genericx86 = "1337"
 
 LAYERSERIES_COMPAT_balena-genericx86 = "honister"
+
+PREFERRED_VERSION_linux-yocto ?= "5.14%"
+


### PR DESCRIPTION
This is needed in order to use the GPU in newer Intel CPUs(Alder Lake).

Changelog-entry: Use kernel 5.14
Signed-off-by: Dor Shahaf <dors@pixellot.tv>
