### PR TITLE
workflows: Update build and deploy to 0.0.6

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release-on-tag:
-    uses: balena-os/github-workflows/.github/workflows/build_and_deploy.yml@v0.0.5
+    uses: balena-os/github-workflows/.github/workflows/build_and_deploy.yml@v0.0.6
     with:
       deployTo: "production"
       final: "no"


### PR DESCRIPTION
This adds support for build and deploy of ESR tags.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>
