### PR TITLE
Add firmware compression for Intel NUC and surface go

### DIFF
--- a/layers/meta-balena-genericx86/conf/layer.conf
+++ b/layers/meta-balena-genericx86/conf/layer.conf
@@ -8,3 +8,6 @@ BBFILE_PATTERN_balena-genericx86 := "^${LAYERDIR}/"
 BBFILE_PRIORITY_balena-genericx86 = "1337"
 
 LAYERSERIES_COMPAT_balena-genericx86 = "honister"
+
+FIRMWARE_COMPRESSION:genericx86-64 = "1"
+FIRMWARE_COMPRESSION:surface-pro-6 = "0"


### PR DESCRIPTION
We use the genericx86-64 machine configuration file from Poky which would
be the preferred place for this setting to be in.

Changelog-entry: Add firmware compression for Intel NUC
Signed-off-by: Alex Gonzalez <alexg@balena.io>