### PR TITLE
meta-balena-genericx86:layer.conf: Enable firmware compression

### DIFF
--- a/layers/meta-balena-genericx86/conf/layer.conf
+++ b/layers/meta-balena-genericx86/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILE_PATTERN_balena-genericx86 := "^${LAYERDIR}/"
 BBFILE_PRIORITY_balena-genericx86 = "1337"
 
 LAYERSERIES_COMPAT_balena-genericx86 = "honister"
+
+FIRMWARE_COMPRESSION ?= "1"

--- a/layers/meta-balena-genericx86/conf/machine/genericx86-64-ext.conf
+++ b/layers/meta-balena-genericx86/conf/machine/genericx86-64-ext.conf
@@ -4,5 +4,3 @@
 
 MACHINEOVERRIDES = "genericx86-64:${MACHINE}"
 include conf/machine/genericx86-64.conf
-
-FIRMWARE_COMPRESSION ?= "1"


### PR DESCRIPTION
Changelog-entry: Enable linux-firmware compression for all Generic x86 based boards
Signed-off-by: Kyle Harding <kyle@balena.io>