### PR TITLE
genericx86-64-ext: qualify visible name w/ legacy MBR

### DIFF
--- a/genericx86-64-ext.coffee
+++ b/genericx86-64-ext.coffee
@@ -21,7 +21,7 @@ module.exports =
 	version: 1
 	slug: 'genericx86-64-ext'
 	aliases: [ 'genericx86-64-ext' ]
-	name: 'Generic x86_64'
+	name: 'Generic x86_64 (legacy MBR)'
 	arch: 'amd64'
 	state: 'new'
 


### PR DESCRIPTION
As we're introducing another generic x86_64 device type with the slug
generic-amd64 that introduces GPT partitioning, add a qualifier to the
existing device type's long name that indicates that it's both legacy,
and uses MBR partitioning.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>