### PR TITLE
linux-yocto: Add I2C character device

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -551,3 +551,9 @@ BALENA_CONFIGS[optimize-size] = " \
 "
 
 BALENA_CONFIGS:remove:genericx86-64-ext = " optimize-size"
+
+BALENA_CONFIGS:append = " i2c-dev"
+BALENA_CONFIGS[i2c-dev] = " \
+    CONFIG_I2C=y \
+    CONFIG_I2C_CHARDEV=m \
+    "


### PR DESCRIPTION
This allows to use user space application to access and modify monitor
settings via the Virtual Control Panel and Monitor Control Command Set
accessible via I2C interfaces.

Fixes #545

Changelog-entry: Add I2C character device kernel module
Signed-off-by: Alex Gonzalez <alexg@balena.io>