### PR TITLE
linux-firmware: Use https protocol on fetch

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-genericx86/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -19,7 +19,7 @@ SRC_URI += " \
 # https://github.com/RPi-Distro/firmware-nonfree
 
 SRC_URI:append = " \
-    git://github.com/RPi-Distro/firmware-nonfree;destsuffix=raspbian-nf;name=raspbian-nf \
+    git://github.com/RPi-Distro/firmware-nonfree;destsuffix=raspbian-nf;protocol=https;name=raspbian-nf \
 "
 
 SRCREV_raspbian-nf = "86e88fbf0345da49555d0ec34c80b4fbae7d0cd3"


### PR DESCRIPTION
The git protocol has now been deprecated by github.

Changelog-entry: use https protocol for linux-firmware fetch
Signed-off-by: Alex Gonzalez <alexg@balena.io>