### PR TITLE
balena-image: include peak driver

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/images/balena-image.bbappend
@@ -7,6 +7,7 @@ BALENA_BOOT_PARTITION_FILES:append = " \
 
 IMAGE_INSTALL:append:genericx86-64-ext =" \
     linux-firmware                        \
+    peak                                  \
 "
 
 IMAGE_ROOTFS_SIZE:genericx86-64-ext = "1024000"


### PR DESCRIPTION
This is a 3rd party CAN driver, we want to include it in the generic device types.