### PR TITLE
machine: genericx86-64-ext: Add x86-64 machine override

### DIFF
--- a/layers/meta-balena-genericx86/conf/machine/genericx86-64-ext.conf
+++ b/layers/meta-balena-genericx86/conf/machine/genericx86-64-ext.conf
@@ -2,7 +2,7 @@
 ##@NAME: genericx86-64-ext
 ##@DESCRIPTION: Machine configuration for an extra configured genericx86-64 device
 
-MACHINEOVERRIDES = "genericx86-64:${MACHINE}"
+MACHINEOVERRIDES = "x86-64:genericx86-64:${MACHINE}"
 include conf/machine/genericx86-64.conf
 
 FIRMWARE_COMPRESSION ?= "1"


### PR DESCRIPTION
This is used in other layer to apply architecture specific changes.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>