### PR TITLE
machine: genericx86-64-ext: add efi and raid machine features

### DIFF
--- a/layers/meta-balena-genericx86/conf/machine/genericx86-64-ext.conf
+++ b/layers/meta-balena-genericx86/conf/machine/genericx86-64-ext.conf
@@ -6,3 +6,5 @@ MACHINEOVERRIDES = "genericx86-64:${MACHINE}"
 include conf/machine/genericx86-64.conf
 
 FIRMWARE_COMPRESSION ?= "1"
+
+MACHINE_FEATURES += " efi raid"


### PR DESCRIPTION
Newer versions of meta-balena use the efi and raid machine features to add user space support.

Changelog-entry: add efi and raid machine features to genericx86-64-ext