### PR TITLE
recipes-kernel: update git ref of 8812au driver

### DIFF
--- a/layers/meta-balena-genericx86/recipes-kernel/rtl8812au/rtl8812au_5.1.5.bb
+++ b/layers/meta-balena-genericx86/recipes-kernel/rtl8812au/rtl8812au_5.1.5.bb
@@ -1,16 +1,16 @@
 SUMMARY = "Realtek 802.11n WLAN Adapter Linux driver"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://Kconfig;md5=86b534dc42246c181a17debcd171f2fa"
+LIC_FILES_CHKSUM = "file://Kconfig;md5=42f39b442650aff3e19aff7af8b6425e"
 MODULES_INSTALL_TARGET = "modules"
 
 inherit module
 
 SRC_URI = " \
-	git://git@github.com/morrownr/8812au-20210629.git;protocol=https;branch=main \
+	git://git@github.com/morrownr/8812au-20210820.git;protocol=https;branch=main \
 "
 
 # Latest head as of today, compatible with kernel 5.15
-SRCREV = "a8450b030a187b71d6be147d004715e6858e0ef9"
+SRCREV = "b350eb84be9808a6748c81711c187e205889e968"
 S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"


### PR DESCRIPTION
The git ref used for the Realtek 802.11n WLAN Adapter Linux driver was deprecated, and to build successfully needed to be updated to an updated ref

Change-type: patch