### PR TITLE
balena-image-initramfs: Remove migrate module for Intel NUC

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,1 +1,9 @@
 IMAGE_ROOTFS_MAXSIZE = "65536"
+
+# The Intel NUC does not have sufficient space in the rootfs
+# and also should not be used for migration
+PACKAGE_INSTALL:remove:genericx86-64 = "initramfs-module-migrate"
+
+# The generic-x86-x64-ext machine inherits the genericx86-64
+# so we need to keep the migrate module for it
+PACKAGE_INSTALL:append:genericx86-64-ext = " initramfs-module-migrate "


### PR DESCRIPTION
to make some free space in the rootfs. The NUC image should not be used as a target for migration anyway

Changelog-entry: balena-image-initramfs: Remove migrate module for Intel NUC

Internal thread: https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/os-config.20update/near/449287399