### PR TITLE
Update meta-balena from 5.2.10 to 5.2.12

### DIFF
--- a/.github/workflows/genericx86-64.yml
+++ b/.github/workflows/genericx86-64.yml
@@ -1,0 +1,57 @@
+name: Generic x86_64 (legacy MBR)
+
+on:
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+  pull_request:
+    branches:
+      - main
+      - master
+      # ESR branches glob pattern
+      - 20[0-9][0-9].[0-1]?[1470].x
+  pull_request_target:
+    branches:
+      - main
+      - master
+  push:
+    tags:
+      # Semver tags glob pattern (includes ESR in format v20YY.MM.PATCH)
+      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      force-finalize:
+        description: Force finalize of the build (implicitly enables hostapp and S3 deployments)
+        required: false
+        type: boolean
+        default: false
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+
+jobs:
+  yocto:
+    name: Yocto
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.27
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
+    secrets: inherit
+    with:
+      machine: genericx86-64-ext
+      # Use qemu workers for testing
+      test_matrix: >
+        {
+          "test_suite": ["os","cloud","hup"],
+          "environment": ["bm.balena-dev.com"],
+          "worker_type": ["qemu"],
+          "runs_on": [["self-hosted", "X64", "kvm"]]
+        }
+      # Allow manual workflow runs to force finalize without checking previous test runs
+      # force-finalize: ${{ inputs.force-finalize || false }}
+      # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
+      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}

--- a/.github/workflows/intel-nuc.yml
+++ b/.github/workflows/intel-nuc.yml
@@ -1,0 +1,57 @@
+name: Intel NUC
+
+on:
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+  pull_request:
+    branches:
+      - main
+      - master
+      # ESR branches glob pattern
+      - 20[0-9][0-9].[0-1]?[1470].x
+  pull_request_target:
+    branches:
+      - main
+      - master
+  push:
+    tags:
+      # Semver tags glob pattern (includes ESR in format v20YY.MM.PATCH)
+      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      force-finalize:
+        description: Force finalize of the build (implicitly enables hostapp and S3 deployments)
+        required: false
+        type: boolean
+        default: false
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+
+jobs:
+  yocto:
+    name: Yocto
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.27
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
+    secrets: inherit
+    with:
+      machine: genericx86-64
+      # Use autokit workers for testing and run on free hosted runners
+      test_matrix: >
+        {
+          "test_suite": ["os","cloud","hup"],
+          "environment": ["bm.balena-dev.com"],
+          "worker_type": ["testbot"],
+          "runs_on": [["ubuntu-latest"]]
+        }
+      # Allow manual workflow runs to force finalize without checking previous test runs
+      # force-finalize: ${{ inputs.force-finalize || false }}
+      # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
+      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}

--- a/.github/workflows/surface-go.yml
+++ b/.github/workflows/surface-go.yml
@@ -1,0 +1,49 @@
+name: Microsoft Surface Go
+
+on:
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+  pull_request:
+    branches:
+      - main
+      - master
+      # ESR branches glob pattern
+      # - 20[0-9][0-9].[0-1]?[1470].x
+  pull_request_target:
+    branches:
+      - main
+      - master
+  push:
+    tags:
+      # Semver tags glob pattern (includes ESR in format v20YY.MM.PATCH)
+      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      force-finalize:
+        description: Force finalize of the build (implicitly enables hostapp and S3 deployments)
+        required: false
+        type: boolean
+        default: false
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+
+jobs:
+  yocto:
+    name: Yocto
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.27
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
+    secrets: inherit
+    with:
+      machine: surface-go
+      # Allow manual workflow runs to force finalize without checking previous test runs
+      # force-finalize: ${{ inputs.force-finalize || false }}
+      # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
+      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}

--- a/.github/workflows/surface-pro-6.yml
+++ b/.github/workflows/surface-pro-6.yml
@@ -1,0 +1,49 @@
+name: Microsoft Surface 6
+
+on:
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+  pull_request:
+    branches:
+      - main
+      - master
+      # ESR branches glob pattern
+      # - 20[0-9][0-9].[0-1]?[1470].x
+  pull_request_target:
+    branches:
+      - main
+      - master
+  push:
+    tags:
+      # Semver tags glob pattern (includes ESR in format v20YY.MM.PATCH)
+      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      force-finalize:
+        description: Force finalize of the build (implicitly enables hostapp and S3 deployments)
+        required: false
+        type: boolean
+        default: false
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+
+jobs:
+  yocto:
+    name: Yocto
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.27
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
+    secrets: inherit
+    with:
+      machine: surface-pro-6
+      # Allow manual workflow runs to force finalize without checking previous test runs
+      # force-finalize: ${{ inputs.force-finalize || false }}
+      # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
+      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}

--- a/layers/meta-balena-genericx86/recipes-kernel/rtl8812au/rtl8812au_5.1.5.bb
+++ b/layers/meta-balena-genericx86/recipes-kernel/rtl8812au/rtl8812au_5.1.5.bb
@@ -1,16 +1,16 @@
 SUMMARY = "Realtek 802.11n WLAN Adapter Linux driver"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://Kconfig;md5=86b534dc42246c181a17debcd171f2fa"
+LIC_FILES_CHKSUM = "file://Kconfig;md5=42f39b442650aff3e19aff7af8b6425e"
 MODULES_INSTALL_TARGET = "modules"
 
 inherit module
 
 SRC_URI = " \
-	git://git@github.com/morrownr/8812au-20210629.git;protocol=https;branch=main \
+	git://git@github.com/morrownr/8812au-20210820.git;protocol=https;branch=main \
 "
 
 # Latest head as of today, compatible with kernel 5.15
-SRCREV = "a8450b030a187b71d6be147d004715e6858e0ef9"
+SRCREV = "b350eb84be9808a6748c81711c187e205889e968"
 S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"


### PR DESCRIPTION
Includes a patch for CVE-2024-6387 and updates balena-supervisor to v16.4.1

Changelog-entry: Update meta-balena from v5.2.10 to v5.2.12

See: https://balena.zulipchat.com/#narrow/stream/403752-channel.2Fsupport-help/topic/Supervisor.20ipv4.2Bipv6.20state/near/467486264
See: https://balena.zendesk.com/agent/tickets/3576