### PR TITLE
Enable force-finalize flag for manual workflow dispatch

### DIFF
--- a/.github/workflows/genericx86-64.yml
+++ b/.github/workflows/genericx86-64.yml
@@ -52,6 +52,6 @@ jobs:
           "runs_on": [["self-hosted", "X64", "kvm"]]
         }
       # Allow manual workflow runs to force finalize without checking previous test runs
-      # force-finalize: ${{ inputs.force-finalize || false }}
+      force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}

--- a/.github/workflows/intel-nuc.yml
+++ b/.github/workflows/intel-nuc.yml
@@ -52,6 +52,6 @@ jobs:
           "runs_on": [["ubuntu-latest"]]
         }
       # Allow manual workflow runs to force finalize without checking previous test runs
-      # force-finalize: ${{ inputs.force-finalize || false }}
+      force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}

--- a/.github/workflows/surface-go.yml
+++ b/.github/workflows/surface-go.yml
@@ -44,6 +44,6 @@ jobs:
     with:
       machine: surface-go
       # Allow manual workflow runs to force finalize without checking previous test runs
-      # force-finalize: ${{ inputs.force-finalize || false }}
+      force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}

--- a/.github/workflows/surface-pro-6.yml
+++ b/.github/workflows/surface-pro-6.yml
@@ -44,6 +44,6 @@ jobs:
     with:
       machine: surface-pro-6
       # Allow manual workflow runs to force finalize without checking previous test runs
-      # force-finalize: ${{ inputs.force-finalize || false }}
+      force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}


### PR DESCRIPTION
This flag was left commented out by mistake before the feature was exposed by the yocto workflow.

Changelog-entry: Enable force-finalize flag for manual workflow dispatch