### PR TITLE
Use Renovate to bump the yocto-scripts workflow sha

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,16 @@
 {
 	"extends": [
 		"github>balena-os/renovate-config"
+	],
+	"packageRules": [
+		{
+			"matchManagers": ["git-submodules"],
+			"matchPackageNames": ["balena-yocto-scripts"],
+			"postUpgradeTasks": {
+				"commands": ["yq '.jobs.*.uses |= sub(\"yocto-build-deploy.yml@[^[:space:]]+$\", \"yocto-build-deploy.yml@{{{newDigest}}}\")' -i .github/workflows/*.yml"],
+				"fileFilters": [".github/workflows/*.yml"],
+				"executionMode": "update"
+			}
+		}
 	]
 }


### PR DESCRIPTION
This will keep the workflow aligned with the submodule.

Change-type: patch