### PR TITLE
balena-image: Set explicit partition size overrides for each machine

### DIFF
--- a/layers/meta-balena-genericx86/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-genericx86/recipes-core/images/balena-image.bbappend
@@ -11,3 +11,15 @@ IMAGE_INSTALL:append:genericx86-64-ext =" \
 "
 
 IMAGE_ROOTFS_SIZE:genericx86-64-ext = "1024000"
+
+BALENA_BOOT_SIZE:genericx86-64-ext = "40960"
+BALENA_STATE_SIZE:genericx86-64-ext = "20480"
+IMAGE_ROOTFS_SIZE:genericx86-64 = "327680"
+BALENA_BOOT_SIZE:genericx86-64 = "40960"
+BALENA_STATE_SIZE:genericx86-64 = "20480"
+IMAGE_ROOTFS_SIZE:surface-go = "327680"
+BALENA_BOOT_SIZE:surface-go = "40960"
+BALENA_STATE_SIZE:surface-go = "20480"
+IMAGE_ROOTFS_SIZE:surface-pro-6 = "327680"
+BALENA_BOOT_SIZE:surface-pro-6 = "40960"
+BALENA_STATE_SIZE:surface-pro-6 = "20480"


### PR DESCRIPTION
## Summary
- Explicitly define `IMAGE_ROOTFS_SIZE`, `BALENA_BOOT_SIZE`, and `BALENA_STATE_SIZE` for every machine target in this repo, preserving any existing custom values and applying fallback defaults (327680/40960/20480) where none were previously set.